### PR TITLE
workaround linting issue

### DIFF
--- a/src/app/desktop/utils/index.js
+++ b/src/app/desktop/utils/index.js
@@ -5,6 +5,7 @@ import { extractFull } from 'node-7z';
 import jimp from 'jimp/es';
 import makeDir from 'make-dir';
 import { promisify } from 'util';
+// eslint-disable-next-line no-unused-vars
 import { ipcRenderer } from 'electron';
 import path from 'path';
 import crypto from 'crypto';


### PR DESCRIPTION
## Purpose
build fails at
```
src/app/desktop/utils/index.js
  Line 8:10:  'ipcRenderer' is defined but never used  no-unused-vars
```

## Approach
Doesn't fix the problem but at least it builds from AUR unlike the other one.

